### PR TITLE
feat(search): search the local index the way the site did

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -24,6 +24,7 @@
         "@tailwindcss/typography": "^0.5.20",
         "@tailwindcss/vite": "4.1.18",
         "@tauri-apps/cli": "^2.9.0",
+        "@types/node": "^26.4.0",
         "@types/react": "^19",
         "@types/react-dom": "^19",
         "@vitejs/plugin-react": "^5.0.0",
@@ -268,6 +269,8 @@
     "@types/mdast": ["@types/mdast@4.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-kGaNbPh1k7AFzgpud/gMdvIm5xuECykRR+JnWKQno9TAXVa6WIVCGTPvYGekIDL4uwCZQSYbUxNBSb1aUo79oA=="],
 
     "@types/ms": ["@types/ms@2.1.0", "", {}, "sha512-GsCCIZDE/p3i96vtEqx+7dBUGXrc7zeSK3wwPHIaRThS+9OhWIXRqzs4d6k1SVU8g91DrNRWxWUGhp5KXQb2VA=="],
+
+    "@types/node": ["@types/node@26.4.0", "", { "dependencies": { "undici-types": "~8.3.0" } }, "sha512-faiGnoIrLH/V8cibOMEAZ8pMw6oXqSukl29ra4mN8GdaB2ZewzeaLj+INpV5N+Z1eKWzY+IzaIZH2EIR6YZRNQ=="],
 
     "@types/react": ["@types/react@19.2.18", "", { "dependencies": { "csstype": "^3.2.2" } }, "sha512-AnzbBERsrLKtk2XSfTbYRLjQPdy116Sty4q+T+Bp3IC4l6jNBvreVPAHmpq9qhXQM7CXZPjLVmGMw9sy+hxQ3w=="],
 
@@ -582,6 +585,8 @@
     "tw-animate-css": ["tw-animate-css@1.4.0", "", {}, "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ=="],
 
     "typescript": ["typescript@5.9.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw=="],
+
+    "undici-types": ["undici-types@8.3.0", "", {}, "sha512-j375ScV60dom+YkPFIfTLcOiPxkN/buHz5GobjLhixFuANaNs3C9l4GmrWqejgXWJ7BbJcFYpTEUkS1Ge8bpZQ=="],
 
     "unified": ["unified@11.0.5", "", { "dependencies": { "@types/unist": "^3.0.0", "bail": "^2.0.0", "devlop": "^1.0.0", "extend": "^3.0.0", "is-plain-obj": "^4.0.0", "trough": "^2.0.0", "vfile": "^6.0.0" } }, "sha512-xKvGhPWw3k84Qjh8bI3ZeJjqnyadK+GEFtazSfZv/rKeTkTjOJho6mFqh2SM96iIcZokxiOpg78GazTSg8+KHA=="],
 

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "@tailwindcss/typography": "^0.5.20",
     "@tailwindcss/vite": "4.1.18",
     "@tauri-apps/cli": "^2.9.0",
+    "@types/node": "^26.4.0",
     "@types/react": "^19",
     "@types/react-dom": "^19",
     "@vitejs/plugin-react": "^5.0.0",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -553,6 +553,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-deque"
+version = "0.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5181e0de7b61eb03a81e347d6dd8797bae9da5146707b51077e2d71a54ec0ceb"
+dependencies = [
+ "crossbeam-epoch",
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -828,6 +847,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "either"
+version = "1.18.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "252afb9ae5eaa683babdc6a068b3f5726eb19e05070c731f9b2a23a7c3e8ed34"
+
+[[package]]
 name = "embed-resource"
 version = "3.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -920,6 +945,18 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
+
+[[package]]
+name = "fallible-iterator"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2acce4a10f12dc2fb14a218589d4f1f62ef011b2d0cc4b3cb1bba8e94da14649"
+
+[[package]]
+name = "fallible-streaming-iterator"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7360491ce676a36bf9bb3c56c1aa791658183a54d2744120f27285738d90465a"
 
 [[package]]
 name = "fastrand"
@@ -1394,9 +1431,30 @@ checksum = "8a9ee70c43aaf417c914396645a0fa852624801b24ebb7ae78fe8272889ac888"
 
 [[package]]
 name = "hashbrown"
+version = "0.16.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash",
+]
+
+[[package]]
+name = "hashlink"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32069d97bb81e38fa67eab65e3393bf804bb85969f2bc06bf13f64aef5aba248"
+dependencies = [
+ "hashbrown 0.17.1",
+]
 
 [[package]]
 name = "heck"
@@ -1426,12 +1484,15 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 name = "houdinimd"
 version = "0.1.0"
 dependencies = [
+ "rayon",
+ "rusqlite",
  "serde",
  "serde_json",
  "tauri",
  "tauri-build",
  "tauri-plugin-opener",
  "wiki",
+ "windows-sys 0.61.2",
  "zip",
 ]
 
@@ -1899,6 +1960,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d7955dfc218a8afb29dfeffd540e3a6e96baeb94fe7138228dd7cc6937fbbf96"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "libsqlite3-sys"
+version = "0.38.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1d20bef17f513b9b3004532233187769cd072d790971f4e4da0e346eb6401e8"
+dependencies = [
+ "cc",
+ "pkg-config",
+ "vcpkg",
 ]
 
 [[package]]
@@ -2606,6 +2678,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "20675572f6f24e9e76ef639bc5552774ed45f1c30e2951e1e99c59888861c539"
 
 [[package]]
+name = "rayon"
+version = "1.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fb39b166781f92d482534ef4b4b1b2568f42613b53e5b6c160e24cfbfa30926d"
+dependencies = [
+ "either",
+ "rayon-core",
+]
+
+[[package]]
+name = "rayon-core"
+version = "1.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+dependencies = [
+ "crossbeam-deque",
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2706,6 +2798,31 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
+]
+
+[[package]]
+name = "rsqlite-vfs"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c51c9ae4df8a7fba42103df5c621fa3c37eccf3a3c650879e90fc48b11cc192c"
+dependencies = [
+ "hashbrown 0.16.1",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "rusqlite"
+version = "0.40.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23f2a97da3e3873c73cb2a2e71b35c40ff95e0b1eefa8d72d8499a6928c3b5b3"
+dependencies = [
+ "bitflags 2.13.1",
+ "fallible-iterator",
+ "fallible-streaming-iterator",
+ "hashlink",
+ "libsqlite3-sys",
+ "smallvec",
+ "sqlite-wasm-rs",
 ]
 
 [[package]]
@@ -3101,6 +3218,18 @@ dependencies = [
  "gobject-sys",
  "libc",
  "system-deps",
+]
+
+[[package]]
+name = "sqlite-wasm-rs"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc3efc0da82635d7e1ced0053bbbfa8c7ab9645d0bf36ceb4f7127bb85315d75"
+dependencies = [
+ "cc",
+ "js-sys",
+ "rsqlite-vfs",
+ "wasm-bindgen",
 ]
 
 [[package]]
@@ -4001,6 +4130,12 @@ dependencies = [
  "serde_core",
  "wasm-bindgen",
 ]
+
+[[package]]
+name = "vcpkg"
+version = "0.2.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "accd4ea62f7bb7a82fe23066fb0957d48ef677f6eeb8215f372f52e48bb32426"
 
 [[package]]
 name = "version-compare"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -24,6 +24,8 @@ serde = { version = "1", features = ["derive"] }
 serde_json = "1"
 zip = { version = "7.2.0", default-features = false, features = ["deflate"] }
 wiki = { version = "0.1.0", path = "crates/wiki" }
+rusqlite = { version = "0.40.2", features = ["bundled"] }
+rayon = "1.12.0"
 
 [profile.release]
 codegen-units = 1
@@ -31,3 +33,6 @@ lto = true
 opt-level = "s"
 panic = "abort"
 strip = true
+
+[target."cfg(windows)".dependencies]
+windows-sys = { version = "0.61.2", features = ["Win32_System_Threading", "Win32_Foundation"] }

--- a/src-tauri/src/db.rs
+++ b/src-tauri/src/db.rs
@@ -1,0 +1,151 @@
+//! The two SQLite files behind the app.
+//!
+//! `index.db` is derived from the Houdini install: parsed pages and the FTS5
+//! table over their bodies. Delete it and nothing of the reader's is lost.
+//! `user.db` holds the reader's own work. It is attached as `user`, so one
+//! statement can join a bookmark to its page title.
+//!
+//! See spec: Local — SQLite FTS5 Index.
+
+use std::path::{Path, PathBuf};
+
+use rusqlite::Connection;
+
+/// `index.db` and `user.db` sit side by side in the app data folder.
+pub fn paths(data: &Path) -> (PathBuf, PathBuf) {
+    (data.join("index.db"), data.join("user.db"))
+}
+
+/// Opens `index.db`, attaches `user.db`, and makes both schemas.
+pub fn open(data: &Path) -> Result<Connection, String> {
+    std::fs::create_dir_all(data).map_err(|e| format!("{}: {e}", data.display()))?;
+    let (index, user) = paths(data);
+    let db = Connection::open(&index).map_err(|e| format!("{}: {e}", index.display()))?;
+
+    // WAL lets the background indexer write while the reader reads.
+    db.pragma_update(None, "journal_mode", "WAL")
+        .map_err(|e| e.to_string())?;
+    db.pragma_update(None, "synchronous", "NORMAL")
+        .map_err(|e| e.to_string())?;
+
+    db.execute("ATTACH DATABASE ?1 AS user", [user.to_string_lossy()])
+        .map_err(|e| format!("{}: {e}", user.display()))?;
+    reset_if_stale(&db)?;
+    db.execute_batch(SCHEMA).map_err(|e| e.to_string())?;
+    Ok(db)
+}
+
+/// What `SCHEMA` describes. Raise it whenever the derived tables change shape.
+const VERSION: u32 = 2;
+
+/// Throws away everything derived from the Houdini install when the shape it
+/// was written in is not the shape this build reads. `index.db` is derived, so
+/// there is nothing here to migrate — the background pass fills it again in
+/// seconds. `user.db` is never touched.
+fn reset_if_stale(db: &Connection) -> Result<(), String> {
+    let found: u32 = db
+        .query_row("PRAGMA user_version", [], |row| row.get(0))
+        .map_err(|e| e.to_string())?;
+    if found != VERSION {
+        db.execute_batch(
+            "DROP TABLE IF EXISTS pages;
+             DROP TABLE IF EXISTS pages_fts;
+             DROP TABLE IF EXISTS builds;",
+        )
+        .map_err(|e| e.to_string())?;
+        db.pragma_update(None, "user_version", VERSION)
+            .map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// One build is one set of rows, never one file and never one folder. A
+/// Houdini upgrade rewrites its own rows and leaves the others alone.
+const SCHEMA: &str = r#"
+CREATE TABLE IF NOT EXISTS builds (
+  build TEXT PRIMARY KEY,
+  pages INTEGER NOT NULL DEFAULT 0,
+  -- 0 while the background pass is still filling this build in.
+  done  INTEGER NOT NULL DEFAULT 0
+);
+
+CREATE TABLE IF NOT EXISTS pages (
+  build     TEXT NOT NULL,
+  path      TEXT NOT NULL,
+  title     TEXT NOT NULL,
+  node_type TEXT,
+  icon      TEXT,
+  summary   TEXT,
+  PRIMARY KEY (build, path)
+) WITHOUT ROWID;
+
+-- One row per SECTION of a page, not per page: a hit names the heading the
+-- reader should land on, which is what the result list draws under the page.
+-- Cutting the body at its headings stores it once, not twice — see
+-- `sections.rs`.
+--
+-- `heading` is empty and `title` is set on the row for the text above the first
+-- heading, so a page is named exactly once and the title weight cannot multiply
+-- with the number of sections it has.
+CREATE VIRTUAL TABLE IF NOT EXISTS pages_fts USING fts5(
+  build   UNINDEXED,
+  path    UNINDEXED,
+  slug    UNINDEXED,
+  heading,
+  title,
+  body,
+  tokenize = "unicode61 remove_diacritics 2"
+);
+
+-- A bookmark names the page, never the page in one build, so an upgrade cannot
+-- empty the list. See spec: Local — Settings and Bookmark Sync.
+CREATE TABLE IF NOT EXISTS user.bookmarks (
+  path  TEXT PRIMARY KEY,
+  added INTEGER NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS user.settings (
+  key   TEXT PRIMARY KEY,
+  value TEXT NOT NULL
+);
+"#;
+
+/// Turns what the reader typed into an FTS5 query.
+///
+/// Every token is quoted, so a bare `*`, `-` or `NEAR` is text and not syntax.
+/// The last token takes a prefix star, because the reader is still typing it.
+pub fn match_query(text: &str) -> Option<String> {
+    let tokens: Vec<String> = text
+        .split(|c: char| !c.is_alphanumeric() && c != '_')
+        .filter(|t| !t.is_empty())
+        .map(|t| format!("\"{t}\""))
+        .collect();
+    let (last, rest) = tokens.split_last()?;
+    let mut query = rest.join(" ");
+    if !query.is_empty() {
+        query.push(' ');
+    }
+    query.push_str(last);
+    query.push('*');
+    Some(query)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::match_query;
+
+    #[test]
+    fn a_query_quotes_every_token_and_extends_the_last() {
+        assert_eq!(match_query("copy to points").unwrap(), "\"copy\" \"to\" \"points\"*");
+    }
+
+    #[test]
+    fn syntax_the_reader_types_stays_text() {
+        assert_eq!(match_query("a OR b*").unwrap(), "\"a\" \"OR\" \"b\"*");
+    }
+
+    #[test]
+    fn nothing_to_match_is_no_query() {
+        assert!(match_query("   ").is_none());
+    }
+}

--- a/src-tauri/src/index.rs
+++ b/src-tauri/src/index.rs
@@ -1,0 +1,272 @@
+//! Fills `index.db` from the zips of a Houdini install.
+//!
+//! Three rules from the spec, in order of importance:
+//! 1. The page the reader opens is parsed on demand, by `page()`. This pass
+//!    never stands between the reader and the first page.
+//! 2. Everything else is filled in behind them.
+//! 3. Houdini wins the core. The thread runs in background mode and the parse
+//!    pool leaves two cores alone.
+//!
+//! See spec: Local — SQLite FTS5 Index.
+
+use std::io::Read;
+use std::path::{Path, PathBuf};
+
+use rayon::prelude::*;
+use rusqlite::Connection;
+use serde::Serialize;
+use tauri::{AppHandle, Emitter};
+
+use crate::db;
+
+/// What the front-end shows while the pass runs, and after it ends.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct Status {
+    pub build: String,
+    /// Pages written so far.
+    pub pages: u32,
+    /// Pages the install holds. Equal to `pages` once the pass is done.
+    pub total: u32,
+    pub done: bool,
+}
+
+/// Starts the background pass for one build. Returns at once.
+pub fn start(app: AppHandle, data: PathBuf, install: crate::install::Install) {
+    std::thread::spawn(move || {
+        background_priority();
+        if let Err(message) = fill(&app, &data, &install) {
+            let _ = app.emit("index-failed", message);
+        }
+    });
+}
+
+/// Reads the state of one build out of an open connection.
+pub fn status(db: &Connection, build: &str) -> Status {
+    let (pages, done) = db
+        .query_row("SELECT pages, done FROM builds WHERE build = ?1", [build], |row| {
+            Ok((row.get::<_, u32>(0)?, row.get::<_, i64>(1)? == 1))
+        })
+        .unwrap_or((0, false));
+    Status { build: build.to_string(), pages, total: pages, done }
+}
+
+fn fill(app: &AppHandle, data: &Path, install: &crate::install::Install) -> Result<(), String> {
+    let mut db = db::open(data)?;
+    pass(&mut db, install, &|status| {
+        let _ = app.emit("index", status);
+    })
+}
+
+/// The pass itself, with nowhere to report to but the closure it is given.
+/// Everything that touches the app handle stays in `fill`.
+pub fn pass(
+    db: &mut Connection,
+    install: &crate::install::Install,
+    report: &dyn Fn(Status),
+) -> Result<(), String> {
+    let build = install.version.clone();
+
+    if status(db, &build).done {
+        report(status(db, &build));
+        return Ok(());
+    }
+
+    // A half-filled build is thrown away rather than resumed. Resuming would
+    // need a per-zip cursor, and a whole pass takes seconds.
+    clear(db, &build)?;
+
+    let zips = sections(&install.help);
+    let total: u32 = zips.iter().map(|(_, count)| count).sum();
+    let mut pages = 0u32;
+    let report = |pages: u32, done: bool| {
+        report(Status { build: build.clone(), pages, total, done });
+    };
+    report(0, false);
+
+    let pool = pool()?;
+    for (zip, _) in &zips {
+        let section = zip.file_stem().and_then(|s| s.to_str()).unwrap_or_default().to_string();
+        let sources = read_zip(zip, &section);
+        let parsed: Vec<Row> = pool.install(|| sources.par_iter().map(row).collect());
+        pages += write(db, &build, &parsed)? as u32;
+        report(pages, false);
+    }
+
+    db.execute(
+        "INSERT INTO builds (build, pages, done) VALUES (?1, ?2, 1)
+         ON CONFLICT(build) DO UPDATE SET pages = ?2, done = 1",
+        rusqlite::params![&build, pages],
+    )
+    .map_err(|e| e.to_string())?;
+    report(pages, true);
+    Ok(())
+}
+
+/// One page, ready to write.
+struct Row {
+    path: String,
+    title: String,
+    node_type: Option<String>,
+    icon: Option<String>,
+    summary: Option<String>,
+    /// The body, cut at its headings. See `sections.rs`.
+    sections: Vec<crate::sections::Section>,
+}
+
+fn row((path, source): &(String, String)) -> Row {
+    let parsed = wiki::parse(source);
+    let markdown = wiki::markdown::blocks(&parsed.blocks, 1);
+    Row {
+        path: path.clone(),
+        title: crate::display_name(&parsed),
+        node_type: crate::node_type(&parsed.props),
+        icon: wiki::model::prop(&parsed.props, "icon").map(|icon| format!("{icon}.svg")),
+        summary: parsed.summary.as_ref().map(|s| wiki::inline::plain(s)),
+        sections: crate::sections::split(&markdown),
+    }
+}
+
+fn write(db: &mut Connection, build: &str, rows: &[Row]) -> Result<usize, String> {
+    let tx = db.transaction().map_err(|e| e.to_string())?;
+    {
+        let mut page = tx
+            .prepare(
+                "INSERT OR REPLACE INTO pages (build, path, title, node_type, icon, summary)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .map_err(|e| e.to_string())?;
+        let mut text = tx
+            .prepare(
+                "INSERT INTO pages_fts (build, path, slug, heading, title, body)
+                 VALUES (?1, ?2, ?3, ?4, ?5, ?6)",
+            )
+            .map_err(|e| e.to_string())?;
+        for row in rows {
+            page.execute(rusqlite::params![
+                build,
+                &row.path,
+                &row.title,
+                &row.node_type,
+                &row.icon,
+                &row.summary
+            ])
+            .map_err(|e| e.to_string())?;
+            // The title rides the FIRST section only. On every section it would
+            // count once per heading, and a long page would outrank the page
+            // actually named for the words.
+            let mut named = false;
+            for section in &row.sections {
+                let title = if named { "" } else { row.title.as_str() };
+                named = true;
+                text.execute(rusqlite::params![
+                    build,
+                    &row.path,
+                    &section.slug,
+                    &section.heading,
+                    title,
+                    &section.body
+                ])
+                .map_err(|e| e.to_string())?;
+            }
+        }
+    }
+    tx.commit().map_err(|e| e.to_string())?;
+    Ok(rows.len())
+}
+
+fn clear(db: &Connection, build: &str) -> Result<(), String> {
+    for statement in [
+        "DELETE FROM pages WHERE build = ?1",
+        "DELETE FROM pages_fts WHERE build = ?1",
+        "DELETE FROM builds WHERE build = ?1",
+    ] {
+        db.execute(statement, [build]).map_err(|e| e.to_string())?;
+    }
+    Ok(())
+}
+
+/// The doc zips and how many pages each one holds. `images.zip` is assets, not
+/// pages; see spec: Local — Image and Asset Serving.
+fn sections(help: &Path) -> Vec<(PathBuf, u32)> {
+    let Ok(entries) = std::fs::read_dir(help) else {
+        return Vec::new();
+    };
+    let mut zips: Vec<PathBuf> = entries
+        .flatten()
+        .map(|entry| entry.path())
+        .filter(|path| path.extension().is_some_and(|e| e == "zip"))
+        .filter(|path| path.file_name().is_some_and(|name| name != "images.zip"))
+        .collect();
+    zips.sort();
+    zips.into_iter()
+        .map(|zip| {
+            let pages = count(&zip);
+            (zip, pages)
+        })
+        .collect()
+}
+
+/// Counts the pages in a zip from its directory alone, without reading a byte
+/// of any entry.
+fn count(zip: &Path) -> u32 {
+    let Ok(archive) = open_zip(zip) else {
+        return 0;
+    };
+    archive.file_names().filter(|name| name.ends_with(".txt")).count() as u32
+}
+
+/// `sop/box.txt` in `nodes.zip` is the page `nodes/sop/box`, which is the path
+/// `help::page` takes back.
+fn read_zip(zip: &Path, section: &str) -> Vec<(String, String)> {
+    let Ok(mut archive) = open_zip(zip) else {
+        return Vec::new();
+    };
+    let names: Vec<String> = archive
+        .file_names()
+        .filter(|name| name.ends_with(".txt"))
+        .map(str::to_string)
+        .collect();
+    let mut pages = Vec::with_capacity(names.len());
+    for name in names {
+        let Ok(mut entry) = archive.by_name(&name) else {
+            continue;
+        };
+        let mut source = String::new();
+        if entry.read_to_string(&mut source).is_err() {
+            continue;
+        }
+        pages.push((format!("{section}/{}", name.trim_end_matches(".txt")), source));
+    }
+    pages
+}
+
+fn open_zip(zip: &Path) -> Result<zip::ZipArchive<std::io::BufReader<std::fs::File>>, String> {
+    let file = std::fs::File::open(zip).map_err(|e| e.to_string())?;
+    zip::ZipArchive::new(std::io::BufReader::new(file)).map_err(|e| e.to_string())
+}
+
+/// Two cores stay free for Houdini. On a four-core machine that is half of
+/// them, which is the point: the artist is not waiting on this pass.
+fn pool() -> Result<rayon::ThreadPool, String> {
+    let cores = std::thread::available_parallelism().map_or(1, |n| n.get());
+    rayon::ThreadPoolBuilder::new()
+        .num_threads(cores.saturating_sub(2).max(1))
+        .build()
+        .map_err(|e| e.to_string())
+}
+
+/// Background mode drops the disk priority of the thread as well as its CPU
+/// priority, which matters more here: the pass reads zips off the same disk
+/// Houdini reads.
+#[cfg(windows)]
+fn background_priority() {
+    use windows_sys::Win32::System::Threading::{
+        GetCurrentThread, SetThreadPriority, THREAD_MODE_BACKGROUND_BEGIN,
+    };
+    unsafe { SetThreadPriority(GetCurrentThread(), THREAD_MODE_BACKGROUND_BEGIN as i32) };
+}
+
+#[cfg(not(windows))]
+fn background_priority() {}
+

--- a/src-tauri/src/install.rs
+++ b/src-tauri/src/install.rs
@@ -30,7 +30,7 @@ pub fn find() -> Vec<Install> {
             continue;
         };
         for entry in entries.flatten() {
-            if let Some(install) = read(entry.path()) {
+            if let Some(install) = read(hfs(entry.path())) {
                 if !found.iter().any(|i| i.version == install.version) {
                     found.push(install);
                 }
@@ -55,16 +55,30 @@ fn read(root: PathBuf) -> Option<Install> {
     })
 }
 
-/// `Houdini 22.0.368` names build 22.0.368.
+/// The build number the path carries, read from the end backwards. Every
+/// platform writes it into one folder along the way, and no two write it the
+/// same: `Houdini 22.0.368` on Windows, `Houdini22.0.368` on macOS, `hfs22.0`
+/// on Linux. The last folder of a macOS install is `Resources`, so the name of
+/// the folder itself is not enough.
 fn version(root: &Path) -> Option<String> {
-    let name = root.file_name()?.to_str()?;
-    let build = name.rsplit(' ').next()?;
-    build
-        .starts_with(|c: char| c.is_ascii_digit())
-        .then(|| build.to_string())
+    root.components()
+        .rev()
+        .filter_map(|part| part.as_os_str().to_str())
+        .find_map(build)
+}
+
+fn build(name: &str) -> Option<String> {
+    let rest = name
+        .strip_prefix("Houdini")
+        .or_else(|| name.strip_prefix("hfs"))
+        .unwrap_or(name)
+        .trim_start();
+    rest.starts_with(|c: char| c.is_ascii_digit())
+        .then(|| rest.to_string())
 }
 
 /// Where the installer puts builds. One entry per drive letter it offers.
+#[cfg(windows)]
 fn roots() -> Vec<PathBuf> {
     let mut roots = Vec::new();
     for var in ["ProgramFiles", "ProgramFiles(x86)"] {
@@ -73,6 +87,23 @@ fn roots() -> Vec<PathBuf> {
         }
     }
     roots
+}
+
+#[cfg(not(windows))]
+fn roots() -> Vec<PathBuf> {
+    vec![PathBuf::from("/Applications/Houdini")]
+}
+
+/// `$HFS` is the install folder on Windows and a framework inside it on macOS,
+/// so what the scan finds is not what the reader gets.
+#[cfg(windows)]
+fn hfs(entry: PathBuf) -> PathBuf {
+    entry
+}
+
+#[cfg(not(windows))]
+fn hfs(entry: PathBuf) -> PathBuf {
+    entry.join("Frameworks/Houdini.framework/Versions/Current/Resources")
 }
 
 /// Sorts `22.0.368` above `20.5.487`, which a string compare gets wrong.

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,8 +1,19 @@
+pub mod db;
 mod help;
-mod install;
+pub mod index;
+pub mod install;
+pub mod sections;
+
+use std::sync::Mutex;
 
 use serde::Serialize;
 use tauri::http::{Request, Response};
+use tauri::{Manager, State};
+
+/// The one connection the reader's own queries run on. `index.db` is open
+/// here with `user.db` attached; the background pass keeps its own connection,
+/// so a long write never holds up a search.
+struct Db(Mutex<rusqlite::Connection>);
 
 /// One page, ready to draw. The body is Markdown, which the front-end renders
 /// with the same component map the site uses.
@@ -40,6 +51,9 @@ struct PageError {
 }
 
 /// Reads and parses one page, such as `nodes/sop/copytopoints`.
+///
+/// This never waits on the index. The first page a reader opens is parsed here
+/// even if the background pass has not reached it yet.
 #[tauri::command]
 fn page(path: String) -> Result<PageView, PageError> {
     let install = current().map_err(|message| PageError { missing: false, message })?;
@@ -52,13 +66,9 @@ fn page(path: String) -> Result<PageView, PageError> {
     })?;
     let parsed = wiki::parse(&source);
     let prop = |name: &str| wiki::model::prop(&parsed.props, name).map(str::to_string);
-    let name = match prop("version") {
-        Some(version) => format!("{} {version}", parsed.title_text),
-        None => parsed.title_text.clone(),
-    };
     Ok(PageView {
         path,
-        name,
+        name: display_name(&parsed),
         node_type: node_type(&parsed.props),
         icon: prop("icon").map(|icon| format!("{icon}.svg")),
         since: prop("since"),
@@ -68,9 +78,166 @@ fn page(path: String) -> Result<PageView, PageError> {
     })
 }
 
+/// A page in the title list, and a search hit. The front-end draws both the
+/// same way, so they are one shape.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Hit {
+    path: String,
+    title: String,
+    node_type: Option<String>,
+    icon: Option<String>,
+    /// What the page says it does, shown when nothing under a heading matched.
+    summary: Option<String>,
+    /// The sections of this page that matched, best first. Empty for a
+    /// title-list entry, which matched no text at all.
+    headings: Vec<Section>,
+    /// How well the words match, larger being better. The front-end weights
+    /// this by what KIND of page it is, which is a question about the reader
+    /// and not about the text — see `weight` in `search.ts`. Zero for a
+    /// title-list entry.
+    score: f64,
+}
+
+/// One matching section of a page: the row the list nests under it.
+#[derive(Serialize)]
+#[serde(rename_all = "camelCase")]
+struct Section {
+    /// Empty when the words were above the first heading.
+    heading: String,
+    /// The anchor to open the page at. Empty with an empty heading.
+    slug: String,
+    /// The words themselves, as they read on the page.
+    excerpt: String,
+}
+
+/// Every page title in the current build.
+///
+/// The whole list goes to the front-end once and stays in memory there, which
+/// is what makes the pick in the search field instant. 10,450 titles are small.
+#[tauri::command]
+fn titles(state: State<Db>) -> Result<Vec<Hit>, String> {
+    let build = current()?.version;
+    let db = state.0.lock().map_err(|e| e.to_string())?;
+    let mut statement = db
+        .prepare(
+            "SELECT path, title, node_type, icon, summary FROM pages
+             WHERE build = ?1 ORDER BY path",
+        )
+        .map_err(|e| e.to_string())?;
+    let rows = statement
+        .query_map([&build], |row| {
+            Ok(Hit {
+                path: row.get(0)?,
+                title: row.get(1)?,
+                node_type: row.get(2)?,
+                icon: row.get(3)?,
+                summary: row.get(4)?,
+                headings: Vec::new(),
+                score: 0.0,
+            })
+        })
+        .map_err(|e| e.to_string())?;
+    rows.collect::<Result<_, _>>().map_err(|e| e.to_string())
+}
+
+/// At most this many matching sections are listed under one page. Past three
+/// the list is a page of one result, and the reader has stopped comparing.
+const SECTIONS_PER_PAGE: usize = 3;
+
+/// Full-text search over the page bodies, ranked with `bm25()`.
+///
+/// A row of the index is a section, so the ranking is over sections and the
+/// pages come out of it: the first section of a page decides where the page
+/// sits, and its other matching sections are listed beneath it. That is what
+/// the result list draws, and it is why the query asks for more rows than the
+/// caller wants pages.
+///
+/// The title and heading columns are weighted above the body, so a page named
+/// for the words beats a page that only mentions them.
+#[tauri::command]
+fn search(state: State<Db>, query: String, limit: u32) -> Result<Vec<Hit>, String> {
+    let Some(match_query) = db::match_query(&query) else {
+        return Ok(Vec::new());
+    };
+    let build = current()?.version;
+    let db = state.0.lock().map_err(|e| e.to_string())?;
+    let mut statement = db
+        .prepare(
+            "SELECT pages_fts.path, p.title, p.node_type, p.icon, p.summary,
+                    pages_fts.heading, pages_fts.slug,
+                    snippet(pages_fts, 5, '', '', '…', 14),
+                    bm25(pages_fts, 0.0, 0.0, 0.0, 4.0, 10.0, 1.0) AS rank
+             FROM pages_fts
+             JOIN pages p ON p.build = pages_fts.build AND p.path = pages_fts.path
+             WHERE pages_fts MATCH ?1 AND pages_fts.build = ?2
+             ORDER BY rank
+             LIMIT ?3",
+        )
+        .map_err(|e| e.to_string())?;
+
+    let wanted = limit as usize;
+    let rows = statement
+        .query_map(
+            rusqlite::params![match_query, build, (wanted * SECTIONS_PER_PAGE * 4) as u32],
+            |row| {
+                Ok((
+                    Hit {
+                        path: row.get(0)?,
+                        title: row.get(1)?,
+                        node_type: row.get(2)?,
+                        icon: row.get(3)?,
+                        summary: row.get(4)?,
+                        headings: Vec::new(),
+                        // `bm25()` is more negative the better the match. The
+                        // front-end multiplies by a weight in 0..1, so the sign
+                        // is turned here and never there.
+                        score: -row.get::<_, f64>(8)?,
+                    },
+                    Section {
+                        heading: row.get(5)?,
+                        slug: row.get(6)?,
+                        excerpt: row.get(7)?,
+                    },
+                ))
+            },
+        )
+        .map_err(|e| e.to_string())?;
+
+    let mut hits: Vec<Hit> = Vec::new();
+    let mut at: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for row in rows {
+        let (hit, section) = row.map_err(|e| e.to_string())?;
+        let index = match at.get(&hit.path) {
+            Some(index) => *index,
+            None => {
+                if hits.len() == wanted {
+                    continue;
+                }
+                at.insert(hit.path.clone(), hits.len());
+                hits.push(hit);
+                hits.len() - 1
+            }
+        };
+        if hits[index].headings.len() < SECTIONS_PER_PAGE && !section.excerpt.trim().is_empty() {
+            hits[index].headings.push(section);
+        }
+    }
+    Ok(hits)
+}
+
+/// How far the background pass has got. The front-end also gets this as an
+/// `index` event, so this call is only for what it missed before it mounted.
+#[tauri::command]
+fn index_status(state: State<Db>) -> Result<index::Status, String> {
+    let build = current()?.version;
+    let db = state.0.lock().map_err(|e| e.to_string())?;
+    Ok(index::status(&db, &build))
+}
+
 /// The header reads "Geometry node", not "sop". The network a node lives in is
 /// the only thing that names its kind, so the label is derived from it.
-fn node_type(props: &wiki::Props) -> Option<String> {
+pub(crate) fn node_type(props: &wiki::Props) -> Option<String> {
     let kind = wiki::model::prop(props, "type")?;
     let context = wiki::model::prop(props, "context")?;
     if kind != "node" {
@@ -91,6 +258,15 @@ fn node_type(props: &wiki::Props) -> Option<String> {
         other => return Some(format!("{other} node")),
     };
     Some(label.to_string())
+}
+
+/// The name a reader sees. A page that carries a `version` property is one
+/// entry of many under the same title, so the version is part of the name.
+pub(crate) fn display_name(parsed: &wiki::Page) -> String {
+    match wiki::model::prop(&parsed.props, "version") {
+        Some(version) => format!("{} {version}", parsed.title_text),
+        None => parsed.title_text.clone(),
+    }
 }
 
 fn current() -> Result<install::Install, String> {
@@ -177,7 +353,22 @@ pub fn run() {
         .plugin(tauri_plugin_opener::init())
         .register_uri_scheme_protocol("hicon", |_app, request| icon_response(request))
         .register_uri_scheme_protocol("himage", |_app, request| image_response(request))
-        .invoke_handler(tauri::generate_handler![installs, page])
+        .setup(|app| {
+            let data = app.path().app_data_dir()?;
+            app.manage(Db(Mutex::new(db::open(&data)?)));
+            if let Ok(install) = current() {
+                index::start(app.handle().clone(), data, install);
+            }
+            Ok(())
+        })
+        .invoke_handler(tauri::generate_handler![
+            installs,
+            page,
+            titles,
+            search,
+            index_status
+        ])
         .run(tauri::generate_context!())
         .expect("error while running the application");
 }
+

--- a/src-tauri/src/sections.rs
+++ b/src-tauri/src/sections.rs
@@ -1,0 +1,209 @@
+//! Splits a rendered page into the sections the search list shows under it.
+//!
+//! A search hit is a SECTION, not a page: the reader wants "Copy to Points >
+//! Fracturing objects", not the page and a guess at where in it. So the FTS
+//! table holds one row per section, which is the whole body once over and not
+//! twice — the sections ARE the body, cut at its headings.
+//!
+//! The anchor each section carries has to be the id the page will really
+//! render, so `slug` mirrors `src/lib/markdown/headings.ts`. The two must agree
+//! or a sub-hit scrolls nowhere.
+
+/// One heading and the text under it. Section 0 of a page is what stands above
+/// the first heading; it has no heading and no anchor.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Section {
+    pub heading: String,
+    pub slug: String,
+    pub body: String,
+}
+
+/// Cuts a rendered markdown body at its headings.
+pub fn split(markdown: &str) -> Vec<Section> {
+    let mut slugger = Slugger::default();
+    let mut sections = vec![Section { heading: String::new(), slug: String::new(), body: String::new() }];
+    let mut fenced = false;
+
+    for line in markdown.lines() {
+        // A `## ` inside a code fence is code, not a heading.
+        if line.trim_start().starts_with("```") {
+            fenced = !fenced;
+        }
+        match heading(line).filter(|_| !fenced) {
+            Some(text) => {
+                let slug = slugger.slug(&text);
+                sections.push(Section { heading: text, slug, body: String::new() });
+            }
+            None => {
+                let body = &mut sections.last_mut().expect("one section always exists").body;
+                body.push_str(line);
+                body.push('\n');
+            }
+        }
+    }
+
+    sections.retain(|section| !section.heading.is_empty() || !section.body.trim().is_empty());
+    // A page with no body at all still needs one row, or its title is indexed
+    // nowhere and the page cannot be found by name.
+    if sections.is_empty() {
+        sections.push(Section { heading: String::new(), slug: String::new(), body: String::new() });
+    }
+    sections
+}
+
+/// The text of an ATX heading below level 1. `#` alone is the page title, which
+/// the header draws and the table of contents leaves out.
+fn heading(line: &str) -> Option<String> {
+    let hashes = line.len() - line.trim_start_matches('#').len();
+    if !(2..=6).contains(&hashes) {
+        return None;
+    }
+    let rest = line[hashes..].strip_prefix(' ')?;
+    let text = plain(rest);
+    (!text.is_empty()).then_some(text)
+}
+
+/// Markdown the heading source carries but the rendered heading does not.
+/// Images go before links, or the generic link rule leaves a stray `!`.
+fn plain(source: &str) -> String {
+    let mut text = strip_tags(source);
+    text = strip_links(&text, true);
+    text = strip_links(&text, false);
+    text = text.replace(['`', '*', '_'], "");
+    for (entity, character) in [("&lt;", "<"), ("&gt;", ">"), ("&amp;", "&"), ("&quot;", "\""), ("&#39;", "'")] {
+        text = text.replace(entity, character);
+    }
+    text.split_whitespace().collect::<Vec<_>>().join(" ")
+}
+
+fn strip_tags(source: &str) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut inside = false;
+    for character in source.chars() {
+        match character {
+            '<' => inside = true,
+            '>' => inside = false,
+            _ if !inside => out.push(character),
+            _ => {}
+        }
+    }
+    out
+}
+
+/// Keeps the label of `[label](target)`, and of `![label](target)` when
+/// `image` is set. Anything unbalanced is left as written.
+fn strip_links(source: &str, image: bool) -> String {
+    let bytes: Vec<char> = source.chars().collect();
+    let mut out = String::with_capacity(source.len());
+    let mut i = 0;
+    while i < bytes.len() {
+        let opens = bytes[i] == '[' && (!image || (i > 0 && bytes[i - 1] == '!'));
+        let Some((label, after)) = opens.then(|| link(&bytes, i)).flatten() else {
+            out.push(bytes[i]);
+            i += 1;
+            continue;
+        };
+        if image {
+            out.pop();
+        }
+        out.push_str(&label);
+        i = after;
+    }
+    out
+}
+
+/// `[label](target)` beginning at `at`, as its label and the index after it.
+fn link(chars: &[char], at: usize) -> Option<(String, usize)> {
+    let close = (at + 1..chars.len()).find(|&i| chars[i] == ']')?;
+    if chars.get(close + 1) != Some(&'(') {
+        return None;
+    }
+    let end = (close + 2..chars.len()).find(|&i| chars[i] == ')')?;
+    Some((chars[at + 1..close].iter().collect(), end + 1))
+}
+
+/// The `github-slugger` rule, which is what the page itself is slugged with:
+/// lower case, drop everything but word characters and dashes, spaces to
+/// dashes, and a `-1`, `-2`… tail on a repeat.
+#[derive(Default)]
+struct Slugger {
+    seen: std::collections::HashMap<String, u32>,
+}
+
+impl Slugger {
+    fn slug(&mut self, text: &str) -> String {
+        let base: String = text
+            .to_lowercase()
+            .chars()
+            .filter(|c| c.is_alphanumeric() || *c == '-' || *c == '_' || *c == ' ')
+            .map(|c| if c == ' ' { '-' } else { c })
+            .collect();
+        let count = self.seen.entry(base.clone()).or_insert(0);
+        let slug = if *count == 0 { base } else { format!("{base}-{count}") };
+        *count += 1;
+        slug
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{split, Slugger};
+
+    #[test]
+    fn the_text_above_the_first_heading_is_its_own_section() {
+        let sections = split("Intro line.\n\n## Parameters\n\nWhat it takes.\n");
+        assert_eq!(sections.len(), 2);
+        assert_eq!(sections[0].heading, "");
+        assert_eq!(sections[0].body.trim(), "Intro line.");
+        assert_eq!(sections[1].heading, "Parameters");
+        assert_eq!(sections[1].slug, "parameters");
+    }
+
+    #[test]
+    fn an_empty_page_still_gets_one_row() {
+        assert_eq!(split("").len(), 1);
+    }
+
+    #[test]
+    fn a_page_with_no_lead_in_starts_at_its_first_heading() {
+        let sections = split("## Overview\n\nText.\n");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].heading, "Overview");
+    }
+
+    #[test]
+    fn a_hash_inside_a_fence_is_code() {
+        let sections = split("## Example\n\n```python\n## not a heading\n```\n");
+        assert_eq!(sections.len(), 1);
+        assert!(sections[0].body.contains("## not a heading"));
+    }
+
+    #[test]
+    fn the_page_title_is_not_a_section() {
+        let sections = split("# Copy to Points\n\nBody.\n");
+        assert_eq!(sections.len(), 1);
+        assert_eq!(sections[0].heading, "");
+    }
+
+    #[test]
+    fn a_heading_is_slugged_the_way_the_page_slugs_it() {
+        let sections = split("## Copy to `Points` 2.0\n\na\n\n## What's new?\n\nb\n");
+        assert_eq!(sections[0].heading, "Copy to Points 2.0");
+        assert_eq!(sections[0].slug, "copy-to-points-20");
+        assert_eq!(sections[1].slug, "whats-new");
+    }
+
+    #[test]
+    fn a_heading_keeps_its_link_label_and_loses_its_image() {
+        let sections = split("## See [Box](/nodes/sop/box) ![i](x.svg)\n\na\n");
+        assert_eq!(sections[0].heading, "See Box i");
+    }
+
+    #[test]
+    fn a_repeated_heading_takes_a_numbered_anchor() {
+        let mut slugger = Slugger::default();
+        assert_eq!(slugger.slug("Notes"), "notes");
+        assert_eq!(slugger.slug("Notes"), "notes-1");
+        assert_eq!(slugger.slug("Notes"), "notes-2");
+    }
+}

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -20,8 +20,8 @@
       }
     ],
     "security": {
-      "csp": "default-src 'self'; img-src 'self' data: http://hicon.localhost http://himage.localhost; media-src 'self' http://himage.localhost; style-src 'self' 'unsafe-inline'",
-      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ws://localhost:1420; img-src 'self' data: http://hicon.localhost http://himage.localhost; media-src 'self' http://himage.localhost; style-src 'self' 'unsafe-inline'"
+      "csp": "default-src 'self'; img-src 'self' data: http://hicon.localhost http://himage.localhost hicon: himage:; media-src 'self' http://himage.localhost himage:; style-src 'self' 'unsafe-inline'",
+      "devCsp": "default-src 'self'; script-src 'self' 'unsafe-inline' 'unsafe-eval'; connect-src 'self' ws://localhost:1420; img-src 'self' data: http://hicon.localhost http://himage.localhost hicon: himage:; media-src 'self' http://himage.localhost himage:; style-src 'self' 'unsafe-inline'"
     }
   },
   "bundle": {

--- a/src/components/root/IndexProgress.tsx
+++ b/src/components/root/IndexProgress.tsx
@@ -1,0 +1,45 @@
+import { useEffect, useState } from "react";
+import { invoke } from "@tauri-apps/api/core";
+import { listen } from "@tauri-apps/api/event";
+import { forgetTitles } from "@/lib/search";
+
+interface Status {
+  build: string;
+  pages: number;
+  total: number;
+  done: boolean;
+}
+
+/**
+ * What the background pass has read so far.
+ *
+ * It says nothing once the pass is done, because a finished index is not news.
+ * Reading a page never waits on it: Rust parses the opened page on demand.
+ * See spec: Local — SQLite FTS5 Index.
+ */
+export function IndexProgress() {
+  const [status, setStatus] = useState<Status | null>(null);
+
+  useEffect(() => {
+    // The pass can finish before this mounts, so the state is read as well as
+    // listened for.
+    invoke<Status>("index_status").then(setStatus).catch(() => {});
+    const stop = listen<Status>("index", (event) => {
+      setStatus(event.payload);
+      // The list the search field holds was taken before these pages existed.
+      if (event.payload.done) forgetTitles();
+    });
+    return () => {
+      stop.then((off) => off());
+    };
+  }, []);
+
+  if (!status || status.done) return null;
+
+  return (
+    <p className="text-meta text-muted-foreground" role="status">
+      Reading the docs — {status.pages.toLocaleString()}
+      {status.total > 0 && ` of ${status.total.toLocaleString()}`} pages
+    </p>
+  );
+}

--- a/src/components/root/search-field/SearchField.tsx
+++ b/src/components/root/search-field/SearchField.tsx
@@ -1,21 +1,42 @@
-import { useEffect, useId, useRef, useState, type FormEvent } from "react";
+import { useEffect, useId, useRef, useState, type FormEvent, type KeyboardEvent } from "react";
 import { useNavigate } from "react-router";
 import { cn } from "@/lib/utils";
+import { bodies, match, pastedPath, resolve, titles, type Hit } from "@/lib/search";
+import {
+  SEARCH_DROPDOWN_CLASS,
+  SearchResultList,
+  rowPath,
+  toRows,
+} from "@/components/search/SearchResultList";
 import { AnimatedPlaceholder } from "./AnimatedPlaceholder";
 import { PasteSearchButton } from "./PasteSearchButton";
 
+/** The body search waits this long after the last key. The title pick does not
+ *  wait at all — it reads a list that is already in memory. */
+const BODY_SEARCH_DELAY = 120;
+
 /**
- * The search field: one input and one key.
+ * The search field: one input, one key, and the list it opens.
  *
- * Until the index lands it opens a help path outright — `nodes/sop/box`.
- * See spec: Local — SQLite FTS5 Index.
+ * Two paths, as the spec says. The titles come back from Rust once and are
+ * picked from in memory, so the list answers every keystroke. The body text is
+ * searched in SQLite with FTS5, a moment behind, and its hits are added under
+ * the title hits. See spec: Local — SQLite FTS5 Index.
  */
 export function SearchField({ className, autoFocus = true }: { className?: string; autoFocus?: boolean }) {
   const navigate = useNavigate();
   const [query, setQuery] = useState("");
+  const [hits, setHits] = useState<Hit[]>([]);
+  const [selected, setSelected] = useState(0);
+  const [open, setOpen] = useState(false);
+  const [error, setError] = useState("");
   const inputRef = useRef<HTMLInputElement>(null);
   const containerRef = useRef<HTMLDivElement>(null);
   const errorId = useId();
+
+  // The list expands each page into its matching sections, so the arrow keys
+  // count rows and not results.
+  const rows = toRows(hits);
 
   useEffect(() => {
     if (autoFocus) inputRef.current?.focus();
@@ -23,27 +44,120 @@ export function SearchField({ className, autoFocus = true }: { className?: strin
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [autoFocus]);
 
-  function open(text: string) {
-    const path = text.trim().replace(/^https?:\/\/[^/]+\/docs\/houdini\//, "").replace(/^\/+/, "");
-    if (path) navigate(`/${path}`);
+  useEffect(() => {
+    function closeOnOutsidePress(event: PointerEvent) {
+      if (!containerRef.current?.contains(event.target as Node)) setOpen(false);
+    }
+    document.addEventListener("pointerdown", closeOnOutsidePress);
+    return () => document.removeEventListener("pointerdown", closeOnOutsidePress);
+  }, []);
+
+  // The list is filled twice for one query: the titles at once, then the body
+  // hits under them. `live` drops the answer to a query the reader has already
+  // typed past.
+  useEffect(() => {
+    const wanted = query.trim();
+    if (!wanted) {
+      setHits([]);
+      setOpen(false);
+      return;
+    }
+    let live = true;
+    setSelected(0);
+
+    const show = (found: Hit[]) => {
+      setHits(found);
+      setOpen(found.length > 0);
+    };
+
+    titles().then((all) => {
+      if (live) show(match(all, wanted));
+    });
+
+    const timer = window.setTimeout(async () => {
+      const [all, found] = await Promise.all([titles(), bodies(wanted)]);
+      if (!live) return;
+      const picked = match(all, wanted);
+      const seen = new Set(picked.map((hit) => hit.path));
+      show([...picked, ...found.filter((hit) => !seen.has(hit.path))]);
+    }, BODY_SEARCH_DELAY);
+
+    return () => {
+      live = false;
+      window.clearTimeout(timer);
+    };
+  }, [query]);
+
+  function go(path: string) {
+    setOpen(false);
+    navigate(`/${path}`);
+  }
+
+  /**
+   * Everything typed goes through here, so nothing can navigate on a guess.
+   * A path or a pasted link names a page; anything else has to be a row of the
+   * list. Text that is neither says so and stays put — opening `/cptp` and
+   * letting the page report itself missing tells the reader their query is
+   * wrong when the search is what fell short.
+   */
+  async function submit(text: string) {
+    const wanted = text.trim();
+    if (!wanted) return;
+    const all = await titles();
+    const hit = resolve(all, wanted, rows[selected]?.hit);
+    if (!hit) {
+      setError(`Nothing in this Houdini build matches “${wanted}”.`);
+      return;
+    }
+    // A row of the list may name a heading of the page, not only the page.
+    go(open && rows[selected]?.hit === hit ? rowPath(rows[selected]) : hit.path);
   }
 
   function handleSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    open(query);
+    void submit(query);
+  }
+
+  function handleKeyDown(event: KeyboardEvent<HTMLInputElement>) {
+    if (event.key === "Escape") {
+      setOpen(false);
+      return;
+    }
+    if (!open || rows.length === 0) return;
+    if (event.key === "ArrowDown" || event.key === "ArrowUp") {
+      event.preventDefault();
+      const step = event.key === "ArrowDown" ? 1 : -1;
+      setSelected((current) => (current + step + rows.length) % rows.length);
+    }
+  }
+
+  function changeQuery(value: string) {
+    setQuery(value);
+    setError("");
+  }
+
+  async function pasteAndSearch() {
+    const text = await navigator.clipboard.readText().catch(() => "");
+    if (!text.trim()) return;
+    changeQuery(text);
+    // A pasted link is a destination, so it opens without waiting for the list.
+    if (pastedPath(text) !== text.trim()) void submit(text);
   }
 
   const mode = query.trim() ? "search" : "paste";
-  const buttonLabel = mode === "search" ? "Open" : "Paste & Open";
+  const buttonLabel = mode === "search" ? "Search" : "Paste & Search";
 
   return (
     // The field overhangs its column by exactly its own padding, so the input
     // text sits on the same left axis as the text above it and only the
     // surface reaches past.
-    <div
-      ref={containerRef}
-      className={cn("relative -mr-xs -ml-ms lg:-ml-md", className)}
-    >
+    <div ref={containerRef} className={cn("relative -mr-xs -ml-ms lg:-ml-md", className)}>
+      {error && (
+        <p id={errorId} className="mb-sm ml-ms text-meta text-destructive lg:ml-md">
+          {error}
+        </p>
+      )}
+
       <form
         onSubmit={handleSubmit}
         role="search"
@@ -104,9 +218,11 @@ export function SearchField({ className, autoFocus = true }: { className?: strin
             ref={inputRef}
             type="text"
             value={query}
-            onChange={(event) => setQuery(event.target.value)}
-            aria-label="Open a page of the Houdini documentation"
-            aria-describedby={errorId}
+            onChange={(event) => changeQuery(event.target.value)}
+            onKeyDown={handleKeyDown}
+            aria-label="Search the Houdini documentation"
+            aria-invalid={!!error}
+            aria-describedby={error ? errorId : undefined}
             autoComplete="off"
             autoCorrect="on"
             autoCapitalize="off"
@@ -119,13 +235,19 @@ export function SearchField({ className, autoFocus = true }: { className?: strin
           {!query && <AnimatedPlaceholder />}
         </div>
 
-        <PasteSearchButton
-          mode={mode}
-          label={buttonLabel}
-          onPaste={() => navigator.clipboard.readText().then(open)}
-        />
+        <PasteSearchButton mode={mode} label={buttonLabel} onPaste={() => void pasteAndSearch()} />
       </form>
 
+      {open && (
+        <SearchResultList
+          hits={hits}
+          query={query}
+          selected={selected}
+          onSelect={setSelected}
+          onActivate={(row) => go(rowPath(row))}
+          className={cn("absolute top-full right-0 left-0 z-10", SEARCH_DROPDOWN_CLASS)}
+        />
+      )}
     </div>
   );
 }

--- a/src/components/search/SearchResultList.tsx
+++ b/src/components/search/SearchResultList.tsx
@@ -1,0 +1,142 @@
+/**
+ * The result list, shared by every search field in the app.
+ *
+ * Everything that decides WHAT a result looks like lives here, so no caller can
+ * grow a plainer list of the same results. The site learned that the hard way:
+ * the row was shared but the model around it was not, and the two fields drifted.
+ *
+ * One thing the site had to do is gone. It fetched each excerpt over the
+ * network, because its index stored WHICH section matched and not what it said.
+ * Here the index is on disk, so Rust returns the words with the hit and a row is
+ * complete the moment it renders.
+ */
+import { useEffect, useMemo, useRef } from "react";
+import { SearchResultRow } from "@/components/search/SearchResultRow";
+import { category, type Hit, type Section } from "@/lib/search";
+
+/**
+ * The look of the predictive list — the single source of truth for it. Only the
+ * surface is here; where the list sits and how high it stacks stays with each
+ * caller, because callers put it in different places.
+ *
+ * No horizontal padding: a list with straight sides of its own wants a
+ * highlighted row to run full width. Only a dropdown inside a card needs a side
+ * gutter, and it adds one below.
+ *
+ * The height is bounded by the viewport as well as by a row count: on a short
+ * window a fixed `max-h` runs off the bottom, where it cannot be scrolled to.
+ */
+export const SEARCH_LIST_CLASS = "py-xs overflow-y-auto overscroll-contain max-h-[min(20rem,60dvh)]";
+
+/** The list as a panel of its own — what a field drops below itself. */
+export const SEARCH_DROPDOWN_CLASS = `mt-sm rounded-xl bg-popover border border-hairline shadow-pane px-xs ${SEARCH_LIST_CLASS}`;
+
+/** One selectable line: a page, one of its matching sections, or its prose. */
+export interface Row {
+  hit: Hit;
+  section?: Section;
+  /** The prose row a page gets when no section of it matched. */
+  text?: boolean;
+}
+
+/**
+ * Flatten pages and their sub-hits into arrow-key order.
+ *
+ * A page with no matching section still gets one row for its own prose, so
+ * every result can show WHY it matched rather than only its title.
+ */
+export function toRows(hits: Hit[], withSubHits = true): Row[] {
+  if (!withSubHits) return hits.map((hit) => ({ hit }));
+  return hits.flatMap((hit) => [
+    { hit },
+    ...(hit.headings?.length
+      ? hit.headings.map((section) => ({ hit, section }))
+      : [{ hit, text: true }]),
+  ]);
+}
+
+/** Where a row goes: the page, or the page at one of its headings. */
+export function rowPath(row: Row): string {
+  return row.section?.slug ? `${row.hit.path}#${row.section.slug}` : row.hit.path;
+}
+
+/** Identifies a row within one result set. */
+const rowKey = (row: Row) => `${row.hit.path}#${row.section?.slug ?? ""}`;
+
+export function SearchResultList({
+  hits,
+  query,
+  selected,
+  onSelect,
+  onActivate,
+  withSubHits = true,
+  header,
+  footer,
+  className,
+  rowRounded = true,
+}: {
+  hits: Hit[];
+  /** What the reader typed, bolded inside each excerpt. */
+  query: string;
+  selected: number;
+  onSelect: (index: number) => void;
+  onActivate: (row: Row) => void;
+  /** Off for lists of pages the reader already chose, where sub-hits are noise. */
+  withSubHits?: boolean;
+  header?: React.ReactNode;
+  footer?: React.ReactNode;
+  className?: string;
+  /** Off for a list with no side gutter, where a rounded row shows corner slivers. */
+  rowRounded?: boolean;
+}) {
+  const rows = useMemo(() => toRows(hits, withSubHits), [hits, withSubHits]);
+  const listRef = useRef<HTMLUListElement>(null);
+
+  // Keeping the selected row in view belongs here and not in each caller: the
+  // site's landing field had no such effect and its arrow keys walked off
+  // screen. Rows are found by index rather than by child position, so an
+  // optional header or footer `li` cannot shift the lookup.
+  useEffect(() => {
+    const list = listRef.current;
+    const row =
+      list?.querySelector(`[data-row="${selected}"]`) ??
+      // Past the last row is the footer, when a caller supplies one.
+      (selected >= rows.length ? list?.lastElementChild : null);
+    row?.scrollIntoView({ block: "nearest" });
+  }, [selected, rows.length]);
+
+  return (
+    <ul ref={listRef} className={className}>
+      {header}
+      {rows.map((row, i) => (
+        <li key={`${rowKey(row)}${row.section || row.text ? ":sub" : ""}`} data-row={i}>
+          <SearchResultRow
+            title={
+              row.section
+                ? row.section.heading || row.hit.title
+                : // A page that says nothing about itself shows its path, never
+                  // its own title again: two identical lines say less than one,
+                  // and the path is what tells two pages of a name apart.
+                  row.text
+                  ? row.hit.summary || row.hit.path
+                  : row.hit.title
+            }
+            category={category(row.hit)}
+            icon={row.hit.icon}
+            sub={Boolean(row.section || row.text)}
+            // A section with no heading is the text above the first one, which
+            // is prose and not a place the reader can be sent to.
+            subKind={row.section?.heading ? "heading" : "text"}
+            excerpt={row.section?.excerpt}
+            query={query}
+            active={i === selected}
+            rounded={rowRounded}
+            onClick={() => onActivate(row)}
+            onMouseMove={() => onSelect(i)}
+          />
+        </li>
+      ))}
+      {footer}
+    </ul>
+  );
+}

--- a/src/components/search/SearchResultRow.tsx
+++ b/src/components/search/SearchResultRow.tsx
@@ -1,0 +1,231 @@
+import { useMemo, useState } from "react";
+import { iconUrl } from "@/lib/assets";
+
+/**
+ * One result row (icon + title + category), and the nested rows under it.
+ *
+ * Ported unchanged in look from the site, so a reader who used the site sees
+ * the same list here. Only where the pictures and the excerpts come from
+ * differs: the site fetched both over the network, the app reads them out of
+ * the Houdini install.
+ */
+
+/**
+ * One icon set, drawn on the Solar Linear grid: 24 viewBox, 1.5 stroke, round
+ * caps, `currentColor`. Sharing the grid is what makes them look related — a
+ * heavier stroke or a different viewBox reads as a different family even at the
+ * same pixel size.
+ */
+function SolarIcon({ className, children }: { className?: string; children: React.ReactNode }) {
+  return (
+    <svg
+      viewBox="0 0 24 24"
+      className={className}
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="1.5"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      {children}
+    </svg>
+  );
+}
+
+/**
+ * Stand-in for pages with no icon of their own — VEX functions, HScript
+ * commands and guide pages, a large part of the corpus. Without it those rows
+ * lose the icon column and their titles sit out of line with the node results
+ * around them.
+ */
+function DocumentIcon() {
+  return (
+    <SolarIcon className="size-5 text-muted-foreground/55">
+      {/* Portrait, like a sheet of paper: 14 wide by 19 tall on the 24 grid. */}
+      <path d="M14 2.5H10c-2.357 0-3.536 0-4.268.732C5 3.964 5 5.143 5 7.5v9c0 2.357 0 3.536.732 4.268.732.732 1.911.732 4.268.732h4c2.357 0 3.536 0 4.268-.732.732-.732.732-1.911.732-4.268V8L14 2.5Z" />
+      <path d="M14 2.5V6c0 .943 0 1.414.293 1.707C14.586 8 15.057 8 16 8h3" />
+      <path d="M9 13.5h6M9 17h4" />
+    </SolarIcon>
+  );
+}
+
+/**
+ * Marks a named section. A `#` from the page font rather than a drawn glyph:
+ * the icon sets all carry a wide, sheared hashtag, and at 17px it reads as a
+ * smear next to the upright strokes of the icons beside it.
+ */
+function HashIcon() {
+  return (
+    <span className="flex size-[1.05rem] items-center justify-center text-[0.95rem] leading-none font-medium">
+      #
+    </span>
+  );
+}
+
+/** Marks prose from the page. Solar "List 1", read here as a paragraph. */
+function ParagraphIcon() {
+  return (
+    <SolarIcon className="size-[1.05rem]">
+      <path d="M20 7H4M15 12H4M9 17H4" />
+    </SolarIcon>
+  );
+}
+
+/**
+ * The plural and the singular of one word, so a query and the page can differ
+ * by an `s` and still highlight. Deliberately only the -s family: stripping
+ * -ing and -ed as well merges words that mean different things in this corpus.
+ */
+function forms(word: string): string[] {
+  if (word.length <= 3) return [word];
+  if (word.endsWith("ies")) return [word, `${word.slice(0, -3)}y`];
+  if (word.endsWith("es") && /[sxzh]$/.test(word.slice(0, -2))) return [word, word.slice(0, -2)];
+  if (word.endsWith("s") && !/(ss|is|us)$/.test(word)) return [word, word.slice(0, -1)];
+  return [word, `${word}s`];
+}
+
+/**
+ * The query, in bold, wherever it appears in the excerpt — so the reader can
+ * see WHY a page matched without reading the whole line.
+ *
+ * The trailing `\w*` catches `point` inside `pointattrib`, and `forms` catches
+ * the other direction, `properties` against the word `property` on the page.
+ */
+function Highlight({ text, query }: { text: string; query: string }) {
+  const parts = useMemo(() => {
+    const words = query.toLowerCase().split(/[^a-z0-9]+/).filter((word) => word.length > 1);
+    const terms = [...new Set(words.flatMap(forms))].sort((a, b) => b.length - a.length);
+    if (!terms.length) return [text];
+    const escaped = terms.map((term) => term.replace(/[.*+?^${}()|[\]\\]/g, "\\$&"));
+    return text.split(new RegExp(`(\\b(?:${escaped.join("|")})\\w*)`, "gi"));
+  }, [text, query]);
+
+  // split() with one capture group alternates: text, match, text, match…
+  return (
+    <>
+      {parts.map((part, i) =>
+        i % 2 ? (
+          <strong key={i} className="font-semibold text-foreground/75">
+            {part}
+          </strong>
+        ) : (
+          part
+        ),
+      )}
+    </>
+  );
+}
+
+export function SearchResultRow({
+  title,
+  category,
+  icon,
+  active,
+  sub,
+  subKind,
+  excerpt,
+  query,
+  rounded = true,
+  onClick,
+  onMouseMove,
+}: {
+  title: string;
+  category: string;
+  icon?: string | null;
+  active: boolean;
+  /** Render as a hit nested under the page row above it. */
+  sub?: boolean;
+  /** What kind of nested hit: a named section, or prose from the page. */
+  subKind?: "heading" | "text";
+  /** Matching prose, shown under the sub-row title. */
+  excerpt?: string;
+  /** What the reader typed, bolded inside the excerpt. */
+  query?: string;
+  /**
+   * Off when the row runs edge to edge (no side gutter around the list): a
+   * rounded highlight against a straight-sided panel shows a sliver of
+   * background at each corner instead of a clean full-bleed bar.
+   */
+  rounded?: boolean;
+  onClick: () => void;
+  onMouseMove: () => void;
+}) {
+  const [loaded, setLoaded] = useState(false);
+  const [errored, setErrored] = useState(false);
+
+  if (sub) {
+    return (
+      <button
+        type="button"
+        // Rounded like the panel that holds it: a square highlight inside a
+        // rounded list reads as a rendering fault at the first and last row.
+        className={`flex w-full items-stretch gap-2.5 pr-4 text-left transition-colors ${rounded ? "rounded-lg" : ""} ${
+          active ? "bg-muted" : "hover:bg-muted/50"
+        }`}
+        onClick={onClick}
+        onMouseMove={onMouseMove}
+      >
+        {/*
+          One unbroken rule down the left of the whole group, so a run of hits
+          reads as belonging to the page above it. Every nested row draws its
+          full height, so consecutive rows join into a single line.
+        */}
+        <span aria-hidden="true" className="ml-[1.6rem] w-px shrink-0 bg-muted-foreground/25" />
+
+        <span className="flex min-w-0 flex-1 items-start gap-2 py-1.5">
+          <span aria-hidden="true" className="mt-px shrink-0 text-muted-foreground/50">
+            {subKind === "text" ? <ParagraphIcon /> : <HashIcon />}
+          </span>
+          <span className="flex min-w-0 flex-col gap-0.5">
+            <span className="truncate text-xs text-muted-foreground">{title}</span>
+            {excerpt && (
+              <span className="line-clamp-2 text-[0.7rem] leading-snug text-muted-foreground/60">
+                {query ? <Highlight text={excerpt} query={query} /> : excerpt}
+              </span>
+            )}
+          </span>
+        </span>
+      </button>
+    );
+  }
+
+  // A broken icon URL falls back to the placeholder rather than pulsing a
+  // skeleton forever, so the icon column stays the same width on every row.
+  const hasImage = Boolean(icon) && !errored;
+
+  return (
+    <button
+      type="button"
+      className={`flex w-full items-center gap-3 px-4 py-2.5 text-left transition-colors ${rounded ? "rounded-lg" : ""} ${
+        active ? "bg-muted" : "hover:bg-muted/50"
+      }`}
+      onClick={onClick}
+      onMouseMove={onMouseMove}
+    >
+      {/* The placeholder is what sits in the slot until the icon arrives, and
+          what stays there if it never does. The site pulsed a grey box instead,
+          which pulses for as long as the window is open when an icon is missing
+          from `icons.zip` and the load neither succeeds nor errors. */}
+      <span className="relative size-5 shrink-0">
+        <span className={`absolute inset-0 transition-opacity ${loaded ? "opacity-0" : "opacity-100"}`}>
+          <DocumentIcon />
+        </span>
+        {hasImage && (
+          <img
+            src={iconUrl(icon!)}
+            alt=""
+            aria-hidden="true"
+            className={`relative size-5 shrink-0 select-none transition-opacity ${loaded ? "opacity-100" : "opacity-0"}`}
+            onLoad={() => setLoaded(true)}
+            onError={() => setErrored(true)}
+          />
+        )}
+      </span>
+      <span className="flex min-w-0 flex-col gap-0.5">
+        <span className="truncate text-sm font-medium">{title}</span>
+        <span className="truncate text-xs text-muted-foreground">{category}</span>
+      </span>
+    </button>
+  );
+}

--- a/src/lib/assets.ts
+++ b/src/lib/assets.ts
@@ -1,12 +1,18 @@
+import { convertFileSrc } from "@tauri-apps/api/core";
+
 /** Where the app reads pictures from: the zips in the Houdini install itself.
-    Rust serves them; see `help.rs`. */
+    Rust serves them; see `help.rs`.
+
+    The address of a custom scheme is not the same on every platform — Windows
+    gets `http://hicon.localhost/…` and macOS gets `hicon://localhost/…` — so
+    Tauri builds it rather than this file. */
 
 /** `SOP/box.svg` in `icons.zip`. */
 export function iconUrl(name: string): string {
-  return `http://hicon.localhost/${name.replace(/^\/+/, "")}`;
+  return convertFileSrc(name.replace(/^\/+/, ""), "hicon");
 }
 
 /** `/images/shelf/copy.jpg` in `images.zip`. */
 export function imageUrl(path: string): string {
-  return `http://himage.localhost/${path.replace(/^\/?(images\/)?/, "")}`;
+  return convertFileSrc(path.replace(/^\/?(images\/)?/, ""), "himage");
 }

--- a/src/lib/search.ts
+++ b/src/lib/search.ts
@@ -1,0 +1,350 @@
+import { invoke } from "@tauri-apps/api/core";
+
+/** One matching section of a page — a row nested under it in the list. */
+export interface Section {
+  /** Empty when the words were above the first heading. */
+  heading: string;
+  /** The anchor to open the page at. Empty with an empty heading. */
+  slug: string;
+  excerpt: string;
+}
+
+/** A page in the title list, and a search hit. Rust sends one shape for both. */
+export interface Hit {
+  path: string;
+  title: string;
+  nodeType?: string | null;
+  icon?: string | null;
+  summary?: string | null;
+  /** Sections that matched, best first. Empty for a title match. */
+  headings?: Section[];
+  /** How well the words match. Weighted by `weight` below, never used raw. */
+  score?: number;
+}
+
+/** Every title in the build, fetched once and kept for the session.
+ *
+ *  10,450 titles are small, and holding them here is what makes the pick
+ *  instant: no round trip while the reader types.
+ *  See spec: Local — SQLite FTS5 Index. */
+let all: Promise<Hit[]> | null = null;
+
+export function titles(): Promise<Hit[]> {
+  all ??= invoke<Hit[]>("titles").catch(() => []);
+  return all;
+}
+
+/** Drops the cache, so the next read sees what the background pass has added. */
+export function forgetTitles() {
+  all = null;
+}
+
+/** Full-text search over the page bodies. Rust ranks it with `bm25()`.
+ *
+ *  The text ranking comes back as it is and is reordered here by what KIND of
+ *  page each hit is. Text scoring alone cannot make that call: the shelf entry
+ *  and the node share a title, and the shelf page is shorter, which BM25
+ *  actively rewards — so "copy to points" answered with the shelf button
+ *  instead of the node. See `weight`. */
+export async function bodies(query: string, limit = 6): Promise<Hit[]> {
+  // Three times what the caller wants, because reordering can only move a page
+  // inside the window it was fetched in, and the node that deserves first place
+  // is often outside a window of six.
+  const hits = await invoke<Hit[]>("search", { query, limit: limit * 3 }).catch(() => []);
+  return hits
+    .sort((a, b) => (b.score ?? 0) * weight(b) - (a.score ?? 0) * weight(a))
+    .slice(0, limit);
+}
+
+/** The section of the docs a path belongs to, as a breadcrumb.
+ *
+ *  Two parts at most. The first is the shelf the page sits on, the second the
+ *  kind of page it is — the same line the site drew under every result, which
+ *  is what tells a SOP and a LOP of the same name apart at a glance. */
+export function category(hit: Hit): string {
+  const [top, second] = hit.path.split("/");
+  switch (top) {
+    // The node type is already the exact label, "Geometry node"; the line names
+    // a family rather than one page, so it is said in the plural.
+    case "nodes":
+      return hit.nodeType ? `Nodes > ${hit.nodeType}s` : "Nodes";
+    case "vex":
+      return second === "functions" ? "VEX > Functions" : "VEX";
+    // The path says `hom`, the docs say Python. The reader typed "python".
+    case "hom":
+      return second && second !== "index" ? `Python scripting > ${second}` : "Python scripting";
+    case "expressions":
+      return "Expression functions";
+    case "hscript":
+      return "HScript commands";
+    case "examples":
+      return "Examples";
+    case "shelf":
+      return "Shelf tools";
+    case "props":
+      return "Properties";
+    default:
+      return top ? top[0].toUpperCase() + top.slice(1) : "";
+  }
+}
+
+/**
+ * SideFX keeps the superseded version of a node at a trailing-dash slug —
+ * `copytopoints-` is v1, `copytopoints` is "Copy to Points 2.0". The old one is
+ * still worth finding, never worth ranking first.
+ */
+const SUPERSEDED = /-$/;
+
+/**
+ * What kind of page this is, from 0 to 1.
+ *
+ * Someone searching "copy points" wants the NODE. An example is a file that
+ * uses it and a shelf entry is a button that runs it; both are worth showing,
+ * below the thing itself. An index page lists pages and is almost never the
+ * page the reader meant.
+ */
+function weight(hit: Hit): number {
+  const path = hit.path;
+  if (path.startsWith("examples/") || path.includes("/examples/")) return 0.55;
+  if (path.endsWith("/index") || path === "index") return 0.6;
+  if (path.startsWith("shelf/")) return 0.7;
+  if (SUPERSEDED.test(path)) return 0.8;
+  // Every node context is a reference page, but a name shared between contexts
+  // ("Attribute Wrangle" is a SOP, a LOP and a COP) has to break the tie
+  // somehow, and SOPs are what most readers are in.
+  if (path.startsWith("nodes/sop/")) return 1;
+  if (/^(nodes|vex|expressions|hscript|hom)\//.test(path)) return 0.97;
+  return 0.9;
+}
+
+/** How well a title or path answers what was typed. 0 means it does not.
+ *
+ *  The ladder is the order a reader means things: the path they typed, the
+ *  name they typed, then the same as a beginning, then the same anywhere. */
+function score(hit: Hit, query: string): number {
+  const path = hit.path.toLowerCase();
+  const title = hit.title.toLowerCase();
+  const leaf = path.slice(path.lastIndexOf("/") + 1);
+  // Names are compared without their spaces, because a slug has none: someone
+  // typing "copy to points" is naming `copytopoints` exactly, and comparing as
+  // written left that page at the substring tier under the LOP of the same
+  // title.
+  const tight = query.replace(/\s+/g, "");
+  const packed = title.replace(/\s+/g, "");
+
+  if (path === query) return 1000;
+  if (leaf === tight || packed === tight) return 900;
+  if (leaf.startsWith(tight) || packed.startsWith(tight)) return 700;
+  if (path.startsWith(query)) return 600;
+  if (title.includes(query)) return 400;
+  if (path.includes(query)) return 300;
+
+  // Words in any order: "points copy" still finds Copy to Points.
+  const words = query.split(/\s+/).filter(Boolean);
+  const text = `${title} ${path}`;
+  return words.length > 1 && words.every((word) => text.includes(word)) ? 200 : 0;
+}
+
+/** The reader is looking for a node far more often than a shelf tool, and for
+ *  a page far more often than the index that lists it. */
+function rank(hit: Hit): number {
+  const section = hit.path.split("/")[0];
+  const depth = hit.path.endsWith("/index") ? 1 : 0;
+  const order = ["nodes", "vex", "hom", "expressions", "props"].indexOf(section);
+  return (order === -1 ? 9 : order) + depth * 10;
+}
+
+/** Below this, an abbreviation matches so much of the corpus it means nothing. */
+const MIN_ABBREVIATION = 3;
+
+/**
+ * At and above this score the query NAMED the page — it is the path, the title,
+ * or the beginning of one. Below it the letters merely appear somewhere, which
+ * is a far weaker reading than an abbreviation of the same letters.
+ */
+const NAMED = 600;
+
+/** The fast pick, straight out of the in-memory list. */
+export function match(hits: Hit[], query: string, limit = 8): Hit[] {
+  const wanted = query.trim().toLowerCase();
+  if (!wanted) return [];
+  const scored = hits
+    .map((hit) => ({ hit, score: score(hit, wanted) }))
+    .filter((row) => row.score > 0)
+    // Weight breaks a tie the text cannot: "Copy to Points" is the exact title
+    // of a SOP and of a LOP, and both are the same length, so without this the
+    // answer is whichever the corpus happened to list first.
+    .sort(
+      (a, b) =>
+        b.score - a.score ||
+        weight(b.hit) - weight(a.hit) ||
+        rank(a.hit) - rank(b.hit) ||
+        a.hit.path.length - b.hit.path.length,
+    )
+    .map((row) => row.hit);
+
+  // Letter-mashing, the way Houdini's TAB menu takes it: `cptp` for Copy to
+  // Points. It runs when nothing NAMED the page, and ahead of the body search,
+  // because the abbreviation is the stronger reading of a query with no spaces.
+  //
+  // "Nothing named it" is not "nothing matched at all". `adpr` is a substring
+  // of `hom/hou/loadPreferences` — lo**adpr**eferences — so a pass gated on an
+  // empty list never runs, and the reader keeps a Python method instead of
+  // Adaptive Prune. The weak hits still follow, under the abbreviations.
+  const named = scored.filter((hit) => score(hit, wanted) >= NAMED);
+  if (named.length === 0 && !/\s/.test(wanted) && wanted.length >= MIN_ABBREVIATION) {
+    const guessed = abbreviated(hits, wanted, limit);
+    const seen = new Set(guessed.map((hit) => hit.path));
+    return [...guessed, ...scored.filter((hit) => !seen.has(hit.path))].slice(0, limit);
+  }
+  return scored.slice(0, limit);
+}
+
+/**
+ * Page families the abbreviation pass is allowed to match.
+ *
+ * Someone mashing letters is reaching for a thing with a name — a node, a VEX
+ * function, an HScript command. Over 11,000 pages, four letters in order match
+ * almost anything: `atwr` alone hits `hapi.createWorkItem` and a destruction
+ * tutorial before it reaches Attribute Wrangle. Houdini's own TAB menu only
+ * ever searches nodes, which is why the matcher behaves there; the families
+ * here are that same idea, widened to the scripting references.
+ */
+const ABBREVIATION_FAMILY = /^(nodes|vex|expressions|hscript|hom)\//;
+
+/**
+ * `cptp` should find "Copy to Points" the way it does in Houdini's own TAB
+ * menu — letters in order, gaps allowed.
+ *
+ * Weight multiplies the score rather than breaking ties. As a tiebreak it would
+ * never fire: two float scores are almost never exactly equal, so a superseded
+ * page would outrank the current one whenever it matched a hair tighter.
+ */
+function abbreviated(hits: Hit[], query: string, limit: number): Hit[] {
+  const scored: Array<{ hit: Hit; score: number }> = [];
+  for (const hit of hits) {
+    if (!ABBREVIATION_FAMILY.test(hit.path) || hit.path.endsWith("/index")) continue;
+    // The trailing version goes: nobody abbreviates the "2.0" in "Copy to
+    // Points 2.0", and counting it as name length lost that SOP to the LOP of
+    // the same name, whose title carries no version at all.
+    const title = subsequence(query, hit.title.replace(/\s+\d+(\.\d+)*$/, ""));
+    const leaf = subsequence(query, hit.path.slice(hit.path.lastIndexOf("/") + 1));
+    if (title === null && leaf === null) continue;
+    scored.push({ hit, score: Math.max(title ?? 0, leaf ?? 0) * weight(hit) });
+  }
+  return scored
+    .sort((a, b) => b.score - a.score)
+    .slice(0, limit)
+    .map((row) => row.hit);
+}
+
+/**
+ * A name reduced to its letters and digits, remembering which of them start a
+ * word. "Copy to Points 2.0" folds to `copytopoints20` with `C`, `t`, `P` and
+ * `2` flagged; `createWorkitem` folds to itself with `c` and `W` flagged.
+ *
+ * Word starts are the whole point of the fold. They are what tells an
+ * abbreviation apart from an accident — see `subsequence`.
+ */
+function fold(text: string): { chars: string; starts: boolean[] } {
+  let chars = "";
+  const starts: boolean[] = [];
+  for (let i = 0; i < text.length; i++) {
+    const ch = text[i];
+    if (!/[a-zA-Z0-9]/.test(ch)) continue;
+    const previous = i > 0 ? text[i - 1] : "";
+    starts.push(
+      chars.length === 0 ||
+        !/[a-zA-Z0-9]/.test(previous) ||
+        (ch >= "A" && ch <= "Z" && previous === previous.toLowerCase()),
+    );
+    chars += ch.toLowerCase();
+  }
+  return { chars, starts };
+}
+
+/**
+ * How well `query` abbreviates `name`, from 0 to 1, or `null` for no match.
+ *
+ * Three rules, and the first is the one that matters. The match must BEGIN at a
+ * word start. People abbreviate from the fronts of words — `adpr` is
+ * **Ad**aptive **Pr**une — so a run that begins mid-word is a coincidence, not
+ * an abbreviation. Without this rule `adpr` returns "Delayed Load Procedural",
+ * because lo**adpr**ocedural holds the letters with no gaps at all and so beats
+ * the page the reader meant on every other measure.
+ *
+ * The rest orders what survives. Density (`query / span`) rewards a tight run;
+ * coverage (`query / name`) rewards the query accounting for most of the name,
+ * which is what separates `copytopoints` from
+ * `geoutils::copytopointstargetattribs` when `cptp` spans 7 characters in both.
+ * The word-start share then lifts a true abbreviation over a tighter accident.
+ *
+ * Every window is scored, not just the shortest, because the shortest window
+ * and the best-aligned one are often not the same.
+ */
+function subsequence(query: string, name: string): number | null {
+  const { chars, starts } = fold(name);
+  if (chars.length < query.length) return null;
+  let best: number | null = null;
+
+  for (let from = 0; from < chars.length; ) {
+    let qi = 0;
+    let end = from;
+    for (; end < chars.length && qi < query.length; end++) {
+      if (chars[end] === query[qi]) qi++;
+    }
+    if (qi < query.length) break; // no complete match remains
+    end--;
+
+    // Pull the start inward to the tightest window with this end.
+    let qk = query.length - 1;
+    let start = end;
+    for (; start >= 0 && qk >= 0; start--) {
+      if (chars[start] === query[qk]) qk--;
+    }
+    start++;
+
+    if (starts[start]) {
+      let onStart = 0;
+      let qj = 0;
+      for (let i = start; i <= end && qj < query.length; i++) {
+        if (chars[i] !== query[qj]) continue;
+        if (starts[i]) onStart++;
+        qj++;
+      }
+      const density = query.length / (end - start + 1);
+      const coverage = query.length / chars.length;
+      const value = density * coverage * (1 + onStart / query.length);
+      if (best === null || value > best) best = value;
+    }
+
+    from = start + 1;
+  }
+
+  return best;
+}
+
+/** A pasted SideFX link, or a path typed by hand, is a page to open outright. */
+export function pastedPath(text: string): string {
+  return text
+    .trim()
+    .replace(/^https?:\/\/[^/]+/, "")
+    .replace(/[#?].*$/, "")
+    .replace(/^\/?docs\/houdini\d*\//, "")
+    .replace(/^\/+|\/+$/g, "")
+    // SideFX serves `box.html`; the page here is `box`.
+    .replace(/\.html?$/, "");
+}
+
+/**
+ * Which page the reader meant by what they typed, or null if nothing does.
+ *
+ * A path or a pasted link names a page outright. Anything else is a query, and
+ * the best row of the list is the answer — the same row Enter opens once they
+ * have arrowed onto it. Nothing else navigates: `cptp` with nothing to show
+ * must stay on the landing page and say so, not open a page that is not there.
+ */
+export function resolve(hits: Hit[], text: string, best?: Hit): Hit | null {
+  const path = pastedPath(text);
+  return hits.find((hit) => hit.path === path) ?? best ?? null;
+}

--- a/src/routes/Home.tsx
+++ b/src/routes/Home.tsx
@@ -6,6 +6,7 @@ import { AsciiBackground } from "@/components/root/AsciiBackground";
 import { NoiseOverlay } from "@/components/root/NoiseOverlay";
 import { QuickLinks } from "@/components/root/QuickLinks";
 import { SearchField } from "@/components/root/search-field/SearchField";
+import { IndexProgress } from "@/components/root/IndexProgress";
 import { FeatureCards } from "@/components/root/feature-cards/FeatureCards";
 
 interface Install {
@@ -45,6 +46,7 @@ export default function Home() {
                   ? `Houdini ${version}`
                   : "No Houdini install found on this machine."}
             </p>
+            <IndexProgress />
           </header>
 
           {/* Order is a real design decision, not a discrepancy: a phone reader

--- a/src/routes/Page.tsx
+++ b/src/routes/Page.tsx
@@ -40,7 +40,8 @@ interface PageView {
 /** The reading view. Rust reads and parses the page; this draws it with the
     same component map the site uses. */
 export default function Page() {
-  const path = useLocation().pathname.replace(/^\/+/, "");
+  const location = useLocation();
+  const path = location.pathname.replace(/^\/+/, "");
   const navigate = useNavigate();
   const [page, setPage] = useState<PageView | null>(null);
   const [error, setError] = useState<PageError | null>(null);
@@ -52,6 +53,18 @@ export default function Page() {
       .then(setPage)
       .catch(setError);
   }, [path]);
+
+  // A search hit names a section, so the reader arrives at `#parameters` and
+  // has to land on it. The anchor is waited for rather than read at once: the
+  // heading does not exist until the markdown above has rendered.
+  useEffect(() => {
+    const id = decodeURIComponent(location.hash.slice(1));
+    if (!id || !page) return;
+    const frame = requestAnimationFrame(() => {
+      document.getElementById(id)?.scrollIntoView({ block: "start" });
+    });
+    return () => cancelAnimationFrame(frame);
+  }, [location.hash, page]);
 
   const isVexPage = /(^|\/)vex\//.test(`/${path}`);
 


### PR DESCRIPTION
The app read the installed docs but could only find a page by substring, so `cptp` returned nothing and then opened /cptp as a 404. The site answered the same query with Copy to Points.

Port the site's ranking and result list, and index sections rather than pages so a hit can name the heading to open at:

- Abbreviation matching, as Houdini's own TAB menu takes it. Letters in order, gaps allowed, and the run must begin at a word start or the match is a coincidence. It runs when nothing NAMED the page, which is not the same as nothing matching at all: `adpr` is a substring of hom/hou/loadPreferences, so a pass gated on an empty list never fires.
- Compare names without their spaces. A slug has none, so someone typing "copy to points" is naming copytopoints exactly; comparing as written left that page under the LOP of the same title.
- Weight a hit by what KIND of page it is. Text scoring cannot make that call: the shelf entry and the node share a title, and the shelf page is shorter, which BM25 actively rewards.
- pages_fts holds one row per section, not per page. The body is cut at its headings, so it is stored once and not twice, and the list can nest matching sections under the page with the words they matched on. index.db carries a user_version, and an index written in the old shape is rebuilt rather than migrated.
- Strip .html from a pasted SideFX link.

Nothing navigates on a guess any more. Text that names no page keeps the reader on the landing page and says so, instead of opening a path that is not there and blaming the query.